### PR TITLE
onelab  requirements文件

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+yacs==0.1.8
+termcolor==2.3.0
+pycocotools==2.0.7


### PR DESCRIPTION
创建了一个requirements文件，用来安装目前发现的onelab镜像环境所缺失的包（这里不包括libai）